### PR TITLE
Add prerun checks to local and platform runs

### DIFF
--- a/src/runner/base.ts
+++ b/src/runner/base.ts
@@ -5,6 +5,7 @@ import { LocalRuntime, Client as MeroxaJS } from "../runtime";
 import { assertIsError, BaseError } from "../errors";
 import { Result, Ok, Err } from "ts-results";
 import { InfoRuntime } from "../runtime/info";
+import { PreflightLocalRuntime } from "../runtime/preflight-local";
 
 export default class Base {
   pathToDataApp: string;
@@ -30,6 +31,15 @@ export default class Base {
   }
 
   async runAppLocal() {
+    const preflightLocalRuntime = new PreflightLocalRuntime(
+      this.pathToDataApp,
+      this.appJSON
+    );
+    await this.dataApp.run(preflightLocalRuntime);
+    if (preflightLocalRuntime.localRunErrors.length > 0) {
+      const preflightErrors = preflightLocalRuntime.localRunErrors.join("\n");
+      return Err(new BaseError(preflightErrors));
+    }
     await this.dataApp.run(this.localRuntime);
     return Ok(true);
   }

--- a/src/runner/primary.ts
+++ b/src/runner/primary.ts
@@ -8,9 +8,18 @@ import { assertIsError, BaseError } from "../errors";
 import { Result, Ok, Err } from "ts-results";
 
 import Base from "./base";
+import { PreflightPlatformRuntime } from "../runtime/preflight-platform";
 
 export default class Primary extends Base {
   async buildFunction(): Promise<Result<string, BaseError>> {
+    const preflightEnvironment = new PreflightPlatformRuntime(this.meroxaJS);
+    this.dataApp.run(preflightEnvironment);
+
+    if (preflightEnvironment.platformRunErrors.length > 0) {
+      const preflightErrors = preflightEnvironment.platformRunErrors.join("\n");
+      return Err(new BaseError(preflightErrors));
+    }
+
     const tmpDir = path.join(os.tmpdir(), "turbine");
     const deployDir = path.join(__dirname, "../function-deploy");
 

--- a/src/runtime/preflight-local.ts
+++ b/src/runtime/preflight-local.ts
@@ -1,0 +1,62 @@
+import { access } from "fs/promises";
+import { AppConfig, Record, Records } from "./types";
+
+export class PreflightLocalRuntime {
+  pathToDataApp: string;
+  appConfig: AppConfig;
+  localRunErrors: string[];
+
+  constructor(pathToDataApp: string, appConfig: AppConfig) {
+    this.pathToDataApp = pathToDataApp;
+    this.appConfig = appConfig;
+    this.localRunErrors = [];
+  }
+
+  async resources(resourceName: string): Promise<PreflightLocalResource> {
+    const resources = this.appConfig.resources;
+    const fixturesPath = resources[resourceName];
+    if (!fixturesPath) {
+      return new PreflightLocalResource(resourceName, "", this.localRunErrors);
+    }
+
+    const resourceFixturesPath = `${this.pathToDataApp}/${fixturesPath}`;
+
+    return new PreflightLocalResource(
+      resourceName,
+      resourceFixturesPath,
+      this.localRunErrors
+    );
+  }
+
+  process(records: Records, fn: (rr: Record[]) => Record[]): void {}
+}
+
+class PreflightLocalResource {
+  name: string;
+  fixturesPath: string;
+  localRunErrors: string[];
+
+  constructor(name: string, fixturesPath: string, localRunErrors: string[]) {
+    this.name = name;
+    this.fixturesPath = fixturesPath;
+    this.localRunErrors = localRunErrors;
+  }
+  async records(collection: string): Promise<void> {
+    if (!this.fixturesPath) {
+      this.localRunErrors.push(
+        `There is no fixture path defined in your app.json for resource '${this.name}'`
+      );
+
+      return;
+    }
+
+    try {
+      await access(this.fixturesPath);
+    } catch (e) {
+      this.localRunErrors.push(
+        `There is no fixture data at path '${this.fixturesPath}' for resource '${this.name}'`
+      );
+    }
+  }
+  write(records: Records, collection: string): void {}
+}

--- a/src/runtime/preflight-platform.ts
+++ b/src/runtime/preflight-platform.ts
@@ -1,0 +1,46 @@
+import { Client } from "meroxa-js";
+import { APIError, BaseError } from "../errors";
+import { Record, Records } from "./types";
+
+export class PreflightPlatformRuntime {
+  client: Client;
+  platformRunErrors: string[];
+
+  constructor(meroxaJS: Client) {
+    this.client = meroxaJS;
+    this.platformRunErrors = [];
+  }
+
+  async resources(resourceName: string): Promise<PreflightPlatformResource> {
+    try {
+      await this.client.resources.get(resourceName);
+      return new PreflightPlatformResource();
+    } catch (e: any) {
+      if (e.response && e.response.status === 404) {
+        this.platformRunErrors.push(
+          `Cannot find resource ${resourceName} on the Meroxa platform, please make sure it exists before using 'turbine.resources('${resourceName}')' in your app.`
+        );
+
+        return new PreflightPlatformResource();
+      }
+
+      if (e.response) {
+        console.log(e.response);
+        throw new APIError(e);
+      }
+
+      if (e.request) {
+        throw new BaseError("no server response");
+      }
+
+      throw e;
+    }
+  }
+
+  process(records: Records, fn: (rr: Record[]) => Record[]): void {}
+}
+
+class PreflightPlatformResource {
+  records(collection: string): void {}
+  write(records: Records, collection: string): void {}
+}


### PR DESCRIPTION
Adds some validations around running your app locally, and also running it on the platform.

+ Checks resources exist on platform
+ Checks fixture paths / files actually exist

## Blockers 
+ [ ] Requires meroxa/cli to pass meroxa auth token during `npx turbine clibuild` call