### PR TITLE
Update bin to use package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
     "tar-fs": "^2.1.1",
     "targz": "^1.0.1"
   },
-  "bin": {
-    "turbine": "bin/turbine"
-  },
+  "bin": "bin/turbine",
   "scripts": {
     "build:dev": "tsc && npm run finish-build",
     "build:prod": "npm run clean-build && tsc --sourceMap false && npm run finish-build",


### PR DESCRIPTION
Updates the turbine-js command to be `@meroxa/turbine-js` instead of `turbine`

## Blockers
+ [x] ~~Needs CLI change TBD~~ change is prepped here https://github.com/meroxa/cli/pull/329 but we will merge this first for publishing