### PR TITLE
Temporarily add tslib for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "fs-extra": "^10.0.0",
     "tar-fs": "^2.1.1",
     "targz": "^1.0.1",
-    "ts-results": "^3.3.0"
+    "ts-results": "^3.3.0",
+    "tslib": "^2.3.1"
   },
   "bin": "bin/turbine",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4200,7 +4200,7 @@ ts-results@^3.3.0:
   resolved "https://registry.yarnpkg.com/ts-results/-/ts-results-3.3.0.tgz#68623a6c18e65556287222dab76498a28154922f"
   integrity sha512-FWqxGX2NHp5oCyaMd96o2y2uMQmSu8Dey6kvyuFdRJ2AzfmWo3kWa4UsPlCGlfQ/qu03m09ZZtppMoY8EMHuiA==
 
-tslib@^2.0.1:
+tslib@^2.0.1, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
Unfortunately ts-results has an implicit dependency on `tslib`. Although this is patched on master in `ts-results` repo, it is not published to npm. We can either fork and publish this library ourselves, or use another library like neverthrow. 

For release, instead of causing a lot of churn, lets just temporarily pull in tslib (no dependencies, least amount of friction)