### PR TITLE
fix(destination): allow collection name setting for snowflake

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@meroxa/meroxa-js": "^1.0.0",
+    "@meroxa/meroxa-js": "^1.0.1",
     "@octokit/rest": "^18.12.0",
     "@types/targz": "^1.0.1",
     "dockerode": "^3.3.1",

--- a/src/runtime/platform.ts
+++ b/src/runtime/platform.ts
@@ -208,6 +208,8 @@ class PlatformResource implements Resource {
         break;
       case "s3":
         connectorConfig["aws_s3_prefix"] = `${collection.toLowerCase()}/`;
+      case "snowflakedb":
+        connectorConfig["snowflake.topic2table.map"] = `${records.stream}:${collection.toLowerCase()}`;
         break;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,10 +1141,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@meroxa/meroxa-js@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@meroxa/meroxa-js/-/meroxa-js-1.0.0.tgz#31d08118da7a0a4cd203c26a3fb8743e52099239"
-  integrity sha512-p4nj8saDIu87nkPum4Vcd8d3VHXKRXakfMf/2CNjipBzjf3/k97NFoffI5tTa0R2hHT0aq73m01sToOv9w7IqA==
+"@meroxa/meroxa-js@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@meroxa/meroxa-js/-/meroxa-js-1.0.1.tgz#41d3290f6db6f7943c1bb7afaf7732cd1b6f77ac"
+  integrity sha512-f6HGyUU0RjmOrGBVrCnB3eW6+lTpzyyIF7H8ghzbMcg6zi72PKY9KVr+JBB3zBgj/Q2OnP+ZMStdo1J8WjvpEA==
   dependencies:
     axios "^0.24.0"
 


### PR DESCRIPTION
Part of https://github.com/meroxa/turbine-project/issues/185

This configures turbine-js to allow for user-defined tablenames in Snowflake destinations.

The Kafka connector configuration for the Snowflake sink connector requires [the `snowflake.topic2table.map` value](https://docs.confluent.io/cloud/current/connectors/cc-snowflake-sink.html#database-details) to be able to identify the table name to which records of a certain Kafka topic should be sent to.

### Connector config (new)

```
{
  "topics": "resource-6968-627574-collection_name",
  "tasks.max": "1",
  "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
  "snowflake.url.name": "{{ resourceAttr \"resource-7dbebc71-a0e0-4614-bc92-49c2d8ba63e9\" \"url.host\" \"no27159.eu-central-1.snowflakecomputing.com\" }}",
  "snowflake.user.name": "jesse",
  "snowflake.private.key": "[redacted]/",
  "snowflake.schema.name": "information_schema",
  "snowflake.database.name": "meroxa_db",
  "snowflake.topic2table.map": "resource-6968-627574-collection_name:anothertablename"
}
```