### PR TITLE
Include template apps with package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "James Martinez <james@meroxa.io>",
   "license": "SEE LICENSE IN LICENSE.MD",
   "files": [
-    "lib/**/*"
+    "lib/**/*",
+    "templates/**/*"
   ],
   "devDependencies": {
     "@types/dockerode": "^3.3.3",


### PR DESCRIPTION
Includes the template apps with the package. It seemed appropriate to leave this outside of the lib folder. confirmed it is being packed 
<img width="326" alt="Screen Shot 2022-04-19 at 4 14 24 PM" src="https://user-images.githubusercontent.com/4818826/164088103-5d7c71de-be58-4a69-9be9-a22efa70b5c1.png">
