### PR TITLE
upd(destination): validate snowflake destination names before deploy

### DIFF
--- a/src/runtime/platform.ts
+++ b/src/runtime/platform.ts
@@ -213,6 +213,12 @@ class PlatformResource implements Resource {
         connectorConfig["aws_s3_prefix"] = `${collection.toLowerCase()}/`;
         break;
       case "snowflakedb":
+        let regexp = /^[a-zA-Z]{1}[a-zA-Z0-9_]*$/;
+        let isCollectionNameValid = regexp.test(collection);
+        if (!isCollectionNameValid) {
+          throw new BaseError(`snowflake destination connector cannot be configured with collection name ${collection}. Only alphanumeric characters and underscores are valid.`);
+        }
+
         connectorConfig["snowflake.topic2table.map"] = `${records.stream}:${collection}`;
         break;
     }


### PR DESCRIPTION
Part of https://github.com/meroxa/turbine-project/issues/194

With this change we will validate the collection name for snowflake destination connectors during app deployments and exit the process if the connector cannot be configured correctly.

| with invalid collection name | with valid collection name |
|--|--|
|![Screen Shot 2022-04-20 at 10 58 16 PM](https://user-images.githubusercontent.com/8811742/164321759-598e5a1a-bfe3-4609-980f-2a6384749527.png)|![Screen Shot 2022-04-20 at 10 58 26 PM](https://user-images.githubusercontent.com/8811742/164321807-0eaed707-8456-4c00-89e8-8173abdf806e.png)|

### Code example for an invalid configuration

```js
  async run(turbine) {
    let source = await turbine.resources("source_name");
    let records = await source.records("collection_name");
    let anonymized = await turbine.process(records, this.anonymize);
    let destination = await turbine.resources("snowflake");
    await destination.write(anonymized, "anicecollectionameforsnowflake");
  }
```


### Code example for a valid configuration

```js
  async run(turbine) {
    let source = await turbine.resources("source_name");
    let records = await source.records("collection_name");
    let anonymized = await turbine.process(records, this.anonymize);
    let destination = await turbine.resources("snowflake");
    await destination.write(anonymized, "notso=nice$collection----.name");
  }
```