### PR TITLE
Add `records` config arg and merge with base cfg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 // Runtime + MeroxaJS
 const { PlatformRuntime, LocalRuntime, Client } = require("./runtime");
 
-module.exports = { PlatformRuntime, LocalRuntime, Client };
+export { PlatformRuntime, LocalRuntime, Client };

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -8,8 +8,15 @@ export interface Runtime {
 }
 
 export interface Resource {
-  records(collection: string): Promise<Records>;
-  write(records: Records, collection: string): void;
+  records(
+    collection: string,
+    connectorConfig: { [index: string]: string }
+  ): Promise<Records>;
+  write(
+    records: Records,
+    collection: string,
+    connectorConfig: { [index: string]: string }
+  ): void;
 }
 
 export interface Record {

--- a/test/unit/platform-runtime-test.ts
+++ b/test/unit/platform-runtime-test.ts
@@ -23,7 +23,7 @@ QUnit.module("Unit | PlatformRuntime", () => {
       pipeline: "default",
       resources: {},
     };
-    const imageName = 'function:awake';
+    const imageName = "function:awake";
 
     const subject = new PlatformRuntime(mockClient, imageName, appConfig);
 
@@ -32,24 +32,27 @@ QUnit.module("Unit | PlatformRuntime", () => {
     assert.deepEqual(subject.appConfig, appConfig);
   });
 
-  QUnit.test("#constructor: validates app config if name is missing", (assert) => {
-    const appConfig: AppConfig = {
-      name: "",
-      language: "js",
-      environment: "common",
-      pipeline: "default",
-      resources: {},
-    };
-    const imageName = 'function:awake';
+  QUnit.test(
+    "#constructor: validates app config if name is missing",
+    (assert) => {
+      const appConfig: AppConfig = {
+        name: "",
+        language: "js",
+        environment: "common",
+        pipeline: "default",
+        resources: {},
+      };
+      const imageName = "function:awake";
 
-    assert.throws(
-      function () {
-        const subject = new PlatformRuntime(mockClient, imageName, appConfig);
-      },
-      /application `name` is required/,
-      'it throws a validation error',
-    );
-  });
+      assert.throws(
+        function () {
+          const subject = new PlatformRuntime(mockClient, imageName, appConfig);
+        },
+        /application `name` is required/,
+        "it throws a validation error"
+      );
+    }
+  );
 
   QUnit.test("#constructor: sets a pipeline name if not set yet", (assert) => {
     const appConfig: AppConfig = {
@@ -59,25 +62,39 @@ QUnit.module("Unit | PlatformRuntime", () => {
       pipeline: "",
       resources: {},
     };
-    const imageName = 'function:awake';
+    const imageName = "function:awake";
 
-    const runtimeInstance = new PlatformRuntime(mockClient, imageName, appConfig);
-    assert.strictEqual(runtimeInstance.appConfig.pipeline, 'turbine-pipeline-sleep-token');
+    const runtimeInstance = new PlatformRuntime(
+      mockClient,
+      imageName,
+      appConfig
+    );
+    assert.strictEqual(
+      runtimeInstance.appConfig.pipeline,
+      "turbine-pipeline-sleep-token"
+    );
   });
 
-  QUnit.test("#constructor: retains original pipeline name if present", (assert) => {
-    const appConfig: AppConfig = {
-      name: "sleep-token",
-      language: "js",
-      environment: "common",
-      pipeline: "awake",
-      resources: {},
-    };
-    const imageName = 'function:awake';
+  QUnit.test(
+    "#constructor: retains original pipeline name if present",
+    (assert) => {
+      const appConfig: AppConfig = {
+        name: "sleep-token",
+        language: "js",
+        environment: "common",
+        pipeline: "awake",
+        resources: {},
+      };
+      const imageName = "function:awake";
 
-    const runtimeInstance = new PlatformRuntime(mockClient, imageName, appConfig);
-    assert.strictEqual(runtimeInstance.appConfig.pipeline, 'awake');
-  });
+      const runtimeInstance = new PlatformRuntime(
+        mockClient,
+        imageName,
+        appConfig
+      );
+      assert.strictEqual(runtimeInstance.appConfig.pipeline, "awake");
+    }
+  );
 
   QUnit.test("resources: it gets a pipeline and a resource", async (assert) => {
     assert.expect(4);
@@ -89,69 +106,80 @@ QUnit.module("Unit | PlatformRuntime", () => {
       pipeline: "awake",
       resources: {},
     };
-    const imageName = 'function:awake';
+    const imageName = "function:awake";
 
     const assertedMockClient = {
       pipelines: {
         get: (name) => {
-          assert.strictEqual(name, 'awake');
+          assert.strictEqual(name, "awake");
           return { name, uuid: 42 };
-        }
+        },
       },
       resources: {
         get: (name) => {
-          assert.strictEqual(name, 'my-db');
+          assert.strictEqual(name, "my-db");
           return { name, id: 24 };
-        }
+        },
       },
     };
 
-    const runtimeInstance = new PlatformRuntime(assertedMockClient, imageName, appConfig);
+    const runtimeInstance = new PlatformRuntime(
+      assertedMockClient,
+      imageName,
+      appConfig
+    );
 
-    let platformResource = await runtimeInstance.resources('my-db');
+    let platformResource = await runtimeInstance.resources("my-db");
 
-    assert.strictEqual(platformResource.resource.name, 'my-db');
-    assert.strictEqual(platformResource.appConfig.pipeline, 'awake');
+    assert.strictEqual(platformResource.resource.name, "my-db");
+    assert.strictEqual(platformResource.appConfig.pipeline, "awake");
   });
 
-  QUnit.test("resources: it creates a pipeline if missing and a resource", async (assert) => {
-    assert.expect(3);
+  QUnit.test(
+    "resources: it creates a pipeline if missing and a resource",
+    async (assert) => {
+      assert.expect(3);
 
-    const appConfig: AppConfig = {
-      name: "sleep-token",
-      language: "js",
-      environment: "common",
-      pipeline: "awake",
-      resources: {},
-    };
-    const imageName = 'function:awake';
+      const appConfig: AppConfig = {
+        name: "sleep-token",
+        language: "js",
+        environment: "common",
+        pipeline: "awake",
+        resources: {},
+      };
+      const imageName = "function:awake";
 
-    const assertedMockClient = {
-      pipelines: {
-        get: (name) => {
-          assert.strictEqual(name, 'awake');
-          throw { response: { status: 404 }};
+      const assertedMockClient = {
+        pipelines: {
+          get: (name) => {
+            assert.strictEqual(name, "awake");
+            throw { response: { status: 404 } };
+          },
+          create: (pipelineInput) => {
+            assert.strictEqual(pipelineInput.name, "awake");
+            assert.strictEqual(pipelineInput.metadata.app, "sleep-token");
+            return { name, uuid: 43 };
+          },
         },
-        create: (pipelineInput) => {
-          assert.strictEqual(pipelineInput.name, 'awake');
-          assert.strictEqual(pipelineInput.metadata.app, 'sleep-token');
-          return { name, uuid: 43 };
+        resources: {
+          get: () => {
+            return { name, id: 24 };
+          },
         },
-      },
-      resources: {
-        get: () => {
-          return { name, id: 24 };
-        }
-      },
-    };
+      };
 
-    const runtimeInstance = new PlatformRuntime(assertedMockClient, imageName, appConfig);
-    try {
-      await runtimeInstance.resources('my-db');
-    } catch(e) {
-      // noop
+      const runtimeInstance = new PlatformRuntime(
+        assertedMockClient,
+        imageName,
+        appConfig
+      );
+      try {
+        await runtimeInstance.resources("my-db");
+      } catch (e) {
+        // noop
+      }
     }
-  });
+  );
 
   QUnit.test("process: it creates a function", async (assert) => {
     assert.expect(4);
@@ -163,27 +191,34 @@ QUnit.module("Unit | PlatformRuntime", () => {
       pipeline: "awake",
       resources: {},
     };
-    const imageName = 'function:awake';
+    const imageName = "function:awake";
 
     const assertedMockClient = {
       functions: {
         create: (functionInput) => {
-          assert.strictEqual(functionInput.input_stream, 'couscous');
-          assert.strictEqual(functionInput.image, 'function:awake');
-          assert.strictEqual(functionInput.pipeline.name, 'awake');
-          return { output_stream: 'bulgur' };
-        }
+          assert.strictEqual(functionInput.input_stream, "couscous");
+          assert.strictEqual(functionInput.image, "function:awake");
+          assert.strictEqual(functionInput.pipeline.name, "awake");
+          return { output_stream: "bulgur" };
+        },
       },
     };
 
-    const runtimeInstance = new PlatformRuntime(assertedMockClient, imageName, appConfig);
+    const runtimeInstance = new PlatformRuntime(
+      assertedMockClient,
+      imageName,
+      appConfig
+    );
 
-    let records = await runtimeInstance.process({ id: 1, stream: 'couscous' }, { name: 'myFn' });
-    assert.strictEqual(records.stream, 'bulgur');
+    let records = await runtimeInstance.process(
+      { id: 1, stream: "couscous" },
+      { name: "myFn" }
+    );
+    assert.strictEqual(records.stream, "bulgur");
   });
 
   QUnit.test("records: it creates a source connector", async (assert) => {
-    assert.expect(6);
+    assert.expect(7);
 
     const appConfig: AppConfig = {
       name: "sleep-token",
@@ -192,41 +227,48 @@ QUnit.module("Unit | PlatformRuntime", () => {
       pipeline: "awake",
       resources: {},
     };
-    const imageName = 'function:awake';
+    const imageName = "function:awake";
 
     const assertedMockClient = {
       connectors: {
         create: (connInput) => {
-          assert.strictEqual(connInput.config.input, 'quinoa');
+          assert.strictEqual(connInput.config.input, "quinoa");
+          assert.strictEqual(connInput.config.hello, "world");
           assert.strictEqual(connInput.resource_id, 24);
-          assert.strictEqual(connInput.metadata['mx:connectorType'], 'source');
-          assert.strictEqual(connInput.pipeline_name, 'awake');
-          return { streams: { output: ['lentils'] }};
-        }
+          assert.strictEqual(connInput.metadata["mx:connectorType"], "source");
+          assert.strictEqual(connInput.pipeline_name, "awake");
+          return { streams: { output: ["lentils"] } };
+        },
       },
       resources: {
         get: (name) => {
           return { name, id: 24 };
-        }
+        },
       },
       pipelines: {
         get: (name) => {
           return { name, uuid: 42 };
-        }
+        },
       },
     };
 
-    const runtimeInstance = new PlatformRuntime(assertedMockClient, imageName, appConfig);
+    const runtimeInstance = new PlatformRuntime(
+      assertedMockClient,
+      imageName,
+      appConfig
+    );
 
-    let platformResource = await runtimeInstance.resources('my-db');
-    let connector = await platformResource.records('quinoa');
+    let platformResource = await runtimeInstance.resources("my-db");
+    let connector = await platformResource.records("quinoa", {
+      hello: "world",
+    });
 
-    assert.strictEqual(connector.stream, 'lentils');
+    assert.strictEqual(connector.stream, "lentils");
     assert.deepEqual(connector.records, []);
   });
 
-  QUnit.test("records: it creates a destination connector", async (assert) => {
-    assert.expect(4);
+  QUnit.test("write: it creates a destination connector", async (assert) => {
+    assert.expect(5);
 
     const appConfig: AppConfig = {
       name: "sleep-token",
@@ -235,32 +277,42 @@ QUnit.module("Unit | PlatformRuntime", () => {
       pipeline: "awake",
       resources: {},
     };
-    const imageName = 'function:awake';
+    const imageName = "function:awake";
 
     const assertedMockClient = {
       connectors: {
         create: (connInput) => {
-          assert.strictEqual(connInput.config.input, 'quinoa');
+          assert.strictEqual(connInput.config.input, "quinoa");
+          assert.strictEqual(connInput.config.hello, "world");
           assert.strictEqual(connInput.resource_id, 24);
-          assert.strictEqual(connInput.metadata['mx:connectorType'], 'destination');
-          assert.strictEqual(connInput.pipeline_name, 'awake');
-        }
+          assert.strictEqual(
+            connInput.metadata["mx:connectorType"],
+            "destination"
+          );
+          assert.strictEqual(connInput.pipeline_name, "awake");
+        },
       },
       resources: {
         get: (name) => {
           return { name, id: 24 };
-        }
+        },
       },
       pipelines: {
         get: (name) => {
           return { name, uuid: 42 };
-        }
+        },
       },
     };
 
-    const runtimeInstance = new PlatformRuntime(assertedMockClient, imageName, appConfig);
+    const runtimeInstance = new PlatformRuntime(
+      assertedMockClient,
+      imageName,
+      appConfig
+    );
 
-    let platformResource = await runtimeInstance.resources('my-db');
-    await platformResource.write({ stream: 'quinoa' }, 'rice');
+    let platformResource = await runtimeInstance.resources("my-db");
+    await platformResource.write({ stream: "quinoa" }, "rice", {
+      hello: "world",
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/meroxa/turbine-project/issues/216

Adds a config argument to the `records` function to allow users to define configuration for their source resource