### PR TITLE
feat(info): return list of used resources in an app

### DIFF
--- a/bin/turbine
+++ b/bin/turbine
@@ -49,6 +49,13 @@ async function executeCommand() {
     if (!commandRun.err) {
       console.log(`\nturbine-response: ${commandRun.val}\n`);
     }
+  } else if (args[0] === "listresources") {
+    // meroxa apps pre-deployment check: return registered resources as per end user's index.js
+    const primaryRunner = new PrimaryRunner(args[1] || process.cwd(), meroxaJS);
+    commandRun = await primaryRunner.listResources();
+    if (!commandRun.err) {
+      console.log(`\nturbine-response: ${commandRun.val}\n`);
+    }
   } else if (args[0] === "clideploy") {
     // meroxa apps deploy step 3 (run users data app / create meroxa platform entities)
     const primaryRunner = new PrimaryRunner(args[2] || process.cwd(), meroxaJS);

--- a/src/runner/base.ts
+++ b/src/runner/base.ts
@@ -53,4 +53,14 @@ export default class Base {
 
     return Ok(functions.val.length > 0);
   }
+
+  async listResources(): Promise<Result<string[], BaseError>> {
+    try {
+      await this.dataApp.run(this.infoRuntime);
+      return Ok(this.infoRuntime.resourcesList);
+    } catch (e) {
+      assertIsError(e);
+      return Err(new BaseError("Error listing resources", e));
+    }
+  }
 }

--- a/src/runtime/info.ts
+++ b/src/runtime/info.ts
@@ -2,6 +2,7 @@ import { AppConfig, Record, Records, RegisteredFunctions } from "./types";
 
 export class InfoRuntime {
   registeredFunctions: RegisteredFunctions = {};
+  registeredResources: string[] = [];
   pathToDataApp: string;
   appConfig: AppConfig;
 
@@ -18,7 +19,12 @@ export class InfoRuntime {
     return `turbine-pipeline-${this.appConfig.name}`;
   }
 
+  get resourcesList(): string[] {
+    return this.registeredResources;
+  }
+
   resources(resourceName: string): InfoResource {
+    this.registeredResources.push(resourceName);
     return new InfoResource();
   }
 

--- a/test/unit/info-runtime-test.ts
+++ b/test/unit/info-runtime-test.ts
@@ -63,4 +63,31 @@ QUnit.module("Unit | InfoRuntime", () => {
     assert.strictEqual(subject.registeredFunctions.anonymize.name, 'anonymize');
     assert.strictEqual(subject.registeredFunctions.capitalize.name, 'capitalize');
   });
+
+  QUnit.test("#resources: it registers resources", (assert) => {
+    const pathToFixtures = "path/to/fixtures";
+    const appConfig: AppConfig = {
+      name: "sleep-token",
+      language: "js",
+      environment: "common",
+      pipeline: "default",
+      resources: {
+        pg: pathToFixtures,
+      },
+    };
+    const pathToDataApp = "/path/to/data/app";
+    const mockResource1 = 'engine';
+    const mockResource2 = 'hydraulik';
+    const subject = new InfoRuntime(pathToDataApp, appConfig);
+
+    // precondition: resources are initially empty
+    assert.deepEqual(subject.registeredResources, []);
+
+    // after registering resources....
+    subject.resources(mockResource1);
+    subject.resources(mockResource2);
+
+    // ...resources are successfully registered
+    assert.deepEqual(subject.registeredResources, ['engine', 'hydraulik']);
+  });
 });


### PR DESCRIPTION
Part of https://github.com/meroxa/turbine-project/issues/85

This will allow the library to return a list of currently used resources as specified in the `index.js`.

This way, the CLI can know which resources have been referenced by the user before an app deployment and compare said list with the resources available in a user's account to verify if they are available or not.

## Usage

The CLI can retrieve a list of resources as follows:

```golang
cmd := exec.command("npx", "--yes", "@meroxa/turbine-js@latestversion", "listresources", path)
```

Which will return the resource names as a list:

```json
[ "engine", "cylinder" ]
```