### PR TITLE
Fix turbine `test` command by unifying Record types

### DIFF
--- a/src/function-deploy/function-app/record.ts
+++ b/src/function-deploy/function-app/record.ts
@@ -10,7 +10,12 @@ export class Record {
   constructor(record: any) {
     this._rawValue = record.value;
     this.key = record.key;
-    this.value = JSON.parse(record.value);
+    try {
+      this.value = JSON.parse(record.value);
+    } catch (e: any) {
+      this.value = record.value;
+    }
+
     this.timestamp = record.timestamp;
   }
 

--- a/src/runtime/info.ts
+++ b/src/runtime/info.ts
@@ -1,4 +1,4 @@
-import { AppConfig, Record, Records, RegisteredFunctions } from "./types";
+import { AppConfig, Records, RecordsArray, RegisteredFunctions } from "./types";
 
 export class InfoRuntime {
   registeredFunctions: RegisteredFunctions = {};
@@ -28,7 +28,7 @@ export class InfoRuntime {
     return new InfoResource();
   }
 
-  process(records: Records, fn: (rr: Record[]) => Record[]): void {
+  process(records: Records, fn: (rr: RecordsArray) => RecordsArray): void {
     this.registeredFunctions[fn.name] = fn;
   }
 }

--- a/src/runtime/local.ts
+++ b/src/runtime/local.ts
@@ -1,4 +1,11 @@
-import { Resource, Record, Records, Runtime, AppConfig } from "./types";
+import {
+  Resource,
+  Record,
+  Records,
+  RecordsArray,
+  Runtime,
+  AppConfig,
+} from "./types";
 import { readFile } from "fs/promises";
 
 export class LocalRuntime implements Runtime {
@@ -18,7 +25,7 @@ export class LocalRuntime implements Runtime {
     return new LocalResource(resourceName, resourceFixturesPath);
   }
 
-  process(records: Records, fn: (rr: Record[]) => Record[]): Records {
+  process(records: Records, fn: (rr: RecordsArray) => RecordsArray): Records {
     let processedRecords = fn(records.records);
     return {
       records: processedRecords,
@@ -58,12 +65,14 @@ async function readFixtures(
   const rawFixtures = await readFile(path);
   let fixtures = JSON.parse(rawFixtures.toString());
   let collectionFixtures = fixtures[collection];
-  let records: Record[] = collectionFixtures.map((fixture: any) => {
-    return {
+  let records = new RecordsArray();
+
+  collectionFixtures.forEach((fixture: any) => {
+    records.pushRecord({
       key: fixture.key,
       value: fixture.value,
       timestamp: Date.now(),
-    };
+    });
   });
 
   return {

--- a/src/runtime/platform.ts
+++ b/src/runtime/platform.ts
@@ -1,4 +1,11 @@
-import { Resource, Record, Records, Runtime, AppConfig } from "./types";
+import {
+  Resource,
+  Record,
+  Records,
+  RecordsArray,
+  Runtime,
+  AppConfig,
+} from "./types";
 
 import {
   Client,
@@ -193,7 +200,7 @@ class PlatformResource implements Resource {
     if (typeof connectorResponse.streams.output === "object") {
       return {
         stream: connectorResponse.streams.output[0],
-        records: [],
+        records: new RecordsArray(),
       };
     } else {
       throw new BaseError("no output stream in response");

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,3 +1,5 @@
+import { Record, RecordsArray } from "../function-deploy/function-app/record";
+
 export interface Runtime {
   resources(name: string): Resource | Promise<Resource>;
   process(
@@ -19,19 +21,15 @@ export interface Resource {
   ): void;
 }
 
-export interface Record {
-  key: string;
-  value: any;
-  timestamp: number;
-}
+export { Record, RecordsArray };
 
 export interface Records {
-  records: Record[];
+  records: RecordsArray;
   stream: string;
 }
 
 export interface RegisteredFunctions {
-  [index: string]: (rr: Record[]) => Record[];
+  [index: string]: (rr: RecordsArray) => RecordsArray;
 }
 
 export interface AppConfig {


### PR DESCRIPTION
The changes from #93 broke how the `test` command works internally, since we were managing two separate types to represent a record (A POJO vs the `Record` class defined in the function app). This fixes that and ensures that the `turbine test` command works.