### PR TITLE
ci(workflows): split out test coverage and default test run into separate workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-app:
-    name: Running Tests
+    name: Test Coverage Report
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Addresses https://github.com/meroxa/turbine-js/pull/97#issuecomment-1145710110

Once this is merged, we can update the branch protection rules to only make the CI workflow `Running Tests` required for merging a PR, unblocking dependency updates for security patches.