### PR TITLE
Update `unwrap` name to be consistent across libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ exports.App = class App {
       );
     });
 
-    records.unwrapCDC();
+    records.unwrap();
 
     return records;
   }
@@ -129,7 +129,7 @@ anonymize(records) {
     );
   });
 
-  records.unwrapCDC();
+  records.unwrap();
 
   return records;
 }
@@ -158,7 +158,7 @@ record.set('nested.key\\.with\\.dot', 'some_value') // Use \\ to set nested keys
 The `records` parameter itself comes with an optional but important function
 
 ```js
-records.unwrapCDC();
+records.unwrap();
 ```
 
 A user can optionally use this transform in their data app function to unwrap CDC formatted records into the right format that destinations expect. Currently, most destinations will not accept CDC formatted data. **_(s3 being an exception)_**

--- a/src/function-deploy/function-app/record.ts
+++ b/src/function-deploy/function-app/record.ts
@@ -55,7 +55,7 @@ export class Record {
     }
   }
 
-  unwrapCDC() {
+  unwrap() {
     if (this.isCDCFormat) {
       const payload = this.value.payload;
       const schemaFields = this.value.schema.fields;
@@ -78,9 +78,9 @@ export class RecordsArray extends Array {
     this.push(new Record(rawRecord));
   }
 
-  unwrapCDC() {
+  unwrap() {
     this.forEach((record: Record) => {
-      record.unwrapCDC();
+      record.unwrap();
     });
   }
 }

--- a/templates/javascript/index.js
+++ b/templates/javascript/index.js
@@ -19,7 +19,7 @@ exports.App = class App {
 
     // Use records `unwrap` transform on CDC formatted records
     // Has no effect on other formats
-    records.unwrapCDC();
+    records.unwrap();
 
     return records;
   }

--- a/test/unit/fn-record-test.ts
+++ b/test/unit/fn-record-test.ts
@@ -143,7 +143,7 @@ QUnit.module("Unit | fn-record", () => {
     );
   });
 
-  QUnit.test("#unwrapCDC with CDC data", (assert) => {
+  QUnit.test("#unwrap with CDC data", (assert) => {
     const rawRecord = {
       key: CDCFixture.collection_name[0].key,
       value: JSON.stringify(CDCFixture.collection_name[0].value),
@@ -151,7 +151,7 @@ QUnit.module("Unit | fn-record", () => {
     };
 
     const record = new Record(rawRecord);
-    record.unwrapCDC();
+    record.unwrap();
 
     assert.notOk(record.value.schema.after);
     assert.strictEqual(
@@ -164,7 +164,7 @@ QUnit.module("Unit | fn-record", () => {
     );
   });
 
-  QUnit.test("#unwrapCDC with non CDC data", (assert) => {
+  QUnit.test("#unwrap with non CDC data", (assert) => {
     const rawRecord = {
       key: nonCDCFixture.collection_name[0].key,
       value: JSON.stringify(nonCDCFixture.collection_name[0].value),
@@ -172,7 +172,7 @@ QUnit.module("Unit | fn-record", () => {
     };
 
     const record = new Record(rawRecord);
-    record.unwrapCDC();
+    record.unwrap();
 
     assert.notOk(record.value.schema.after);
     assert.strictEqual(record.value.schema.name, "collection_name");

--- a/test/unit/fn-records-array-test.ts
+++ b/test/unit/fn-records-array-test.ts
@@ -16,7 +16,7 @@ QUnit.module("Unit | fn-records-array", () => {
     assert.strictEqual(records[0].constructor.name, "Record");
   });
 
-  QUnit.test("#unwrapCDC", (assert) => {
+  QUnit.test("#unwrap", (assert) => {
     const rawRecord = {
       key: CDCFixture.collection_name[0].key,
       value: JSON.stringify(CDCFixture.collection_name[0].value),
@@ -25,8 +25,8 @@ QUnit.module("Unit | fn-records-array", () => {
     const records = new RecordsArray();
     records.pushRecord(rawRecord);
 
-    const recordUnwrapStub = sinon.stub(records[0], "unwrapCDC");
-    records.unwrapCDC();
+    const recordUnwrapStub = sinon.stub(records[0], "unwrap");
+    records.unwrap();
 
     assert.ok(recordUnwrapStub.calledOnce);
   });


### PR DESCRIPTION
Updates the `unwrap` transform's name to be the same as we use in turbine-go