### PR TITLE
Add dummy INPUT_TOKEN to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,5 @@ jobs:
          yarn add @octokit/action
          node .github/actions/github-release.js
         env:
+          INPUT_TOKEN: ''
           GITHUB_TOKEN: ${{ secrets.MEROXA_MACHINE }}


### PR DESCRIPTION
Fixes an issue where the runner expects an `INPUT_TOKEN` to be available due to the previous steps npm publish. Adds a blank dummy token that acts as a placeholder (it isnt actually used)