### PR TITLE
Fix IR secrets to return object instead of array

### DIFF
--- a/packages/turbine-js-cli/src/runtime/platform-v2.ts
+++ b/packages/turbine-js-cli/src/runtime/platform-v2.ts
@@ -3,7 +3,7 @@ import { Records, RecordsArray } from "./types";
 export class PlatformV2Runtime {
   registeredResources: PlatformV2Resource[] = [];
   registeredFunctions: PlatformV2Function[] = [];
-  registeredSecrets: { [index: string]: string }[] = [];
+  registeredSecrets: { [index: string]: string } = {};
 
   appName: string;
   imageName: string;
@@ -59,11 +59,7 @@ export class PlatformV2Runtime {
 
     const envVarsKeys = Object.keys(envVars);
     if (envVarsKeys.length > 0) {
-      this.registeredSecrets = envVarsKeys.map((key) => {
-        return {
-          [key]: envVars[key],
-        };
-      });
+      this.registeredSecrets = Object.assign({}, envVars);
     }
   }
 

--- a/packages/turbine-js-cli/test/unit/platform-v2-test.ts
+++ b/packages/turbine-js-cli/test/unit/platform-v2-test.ts
@@ -126,11 +126,8 @@ QUnit.module("Unit | PlatformV2Runtime", () => {
     assert.ok(runtime.registeredFunctions[0] instanceof PlatformV2Function);
     assert.strictEqual(runtime.registeredFunctions[0].name, "aFn-12345678");
     assert.strictEqual(runtime.registeredFunctions[0].image, "imageName");
-    assert.strictEqual(runtime.registeredSecrets.length, 1);
-    assert.strictEqual(
-      runtime.registeredSecrets[0].A_ENV_VAR,
-      "sleeptokenrocks"
-    );
+    assert.strictEqual(Object.keys(runtime.registeredSecrets).length, 1);
+    assert.strictEqual(runtime.registeredSecrets.A_ENV_VAR, "sleeptokenrocks");
   });
 
   QUnit.test("#serializeToIR", (assert) => {
@@ -173,7 +170,7 @@ QUnit.module("Unit | PlatformV2Runtime", () => {
         },
       ],
       functions: [{ name: "aFn-12345678", image: "imageName" }],
-      secrets: [{ A_ENV_VAR: "sleeptokenrocks" }],
+      secrets: { A_ENV_VAR: "sleeptokenrocks" },
       definition: {
         app_name: "appName",
         git_sha: "123456789",


### PR DESCRIPTION
Updates secrets to return an object instead of an array with the env var secrets