### PR TITLE
bump(version): release 1.1.0 of cli + framework repos

### DIFF
--- a/.changeset/famous-hornets-kick.md
+++ b/.changeset/famous-hornets-kick.md
@@ -1,0 +1,17 @@
+---
+"@meroxa/turbine-js-cli": minor
+"@meroxa/turbine-js-framework": minor
+---
+
+## What's Changed
+
+* Monorepo turbine into packages by @jmar910 in https://github.com/meroxa/turbine-js/pull/115
+* Remove release workflow until we support monorepos by @jmar910 in https://github.com/meroxa/turbine-js/pull/129
+* Add IR runtime by @jmar910 in https://github.com/meroxa/turbine-js/pull/130
+* Add changesets GitHub action by @jmar910 in https://github.com/meroxa/turbine-js/pull/131
+* Fix IR secrets to return object instead of array by @jmar910 in https://github.com/meroxa/turbine-js/pull/133
+* upd(resources): allow automatic configuration of kafka-type connectors by @jayjayjpg in https://github.com/meroxa/turbine-js/pull/135
+* Add validations for single source and collections by @jmar910 in https://github.com/meroxa/turbine-js/pull/134
+
+
+**Full Changelog**: https://github.com/meroxa/turbine-js/compare/v0.5.0...v0.6.0


### PR DESCRIPTION
Releases all changes listed in https://github.com/meroxa/turbine-js/releases/tag/v0.6.0