### PR TITLE
Add dependabot config to automatically update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ".github:"
+
+  # Maintain dependencies for Node
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "package.json:"
+
+  # Maintain dependencies for Docker
+  - package-ecosystem: "docker"
+    directory: "/lib/function-deploy/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Dockerfile:"
+
+  - package-ecosystem: "docker"
+    directory: "/packages/turbine-js-cli/templates"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Dockerfile:"


### PR DESCRIPTION
 Dependabot should open PRs as new versions are found weekly.

Related to https://github.com/meroxa/engineering/issues/24