### PR TITLE
Customize changeset versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,7 @@ jobs:
 
       - name: Create Release Pull Request
         uses: changesets/action@v1
+        with:
+          version: npm run version
         env:
           GITHUB_TOKEN: ${{ secrets.MEROXA_MACHINE }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5853,11 +5853,11 @@
     },
     "packages/turbine-js-cli": {
       "name": "@meroxa/turbine-js-cli",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.MD",
       "dependencies": {
         "@meroxa/meroxa-js": "^1.3.0",
-        "@meroxa/turbine-js-framework": "^1.0.0",
+        "@meroxa/turbine-js-framework": "^1.1.0",
         "@octokit/rest": "^18.12.0",
         "dockerode": "^3.3.1",
         "fs-extra": "^10.0.0",
@@ -5919,7 +5919,7 @@
     },
     "packages/turbine-js-framework": {
       "name": "@meroxa/turbine-js-framework",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.MD",
       "dependencies": {
         "@grpc/grpc-js": "^1.4.5",
@@ -6792,7 +6792,7 @@
       "version": "file:packages/turbine-js-cli",
       "requires": {
         "@meroxa/meroxa-js": "^1.3.0",
-        "@meroxa/turbine-js-framework": "^1.0.0",
+        "@meroxa/turbine-js-framework": "^1.1.0",
         "@octokit/rest": "^18.12.0",
         "@types/dockerode": "^3.3.3",
         "@types/fs-extra": "^9.0.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "@meroxa/turbine-js",
-      "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE.MD",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@meroxa/turbine-js",
-  "version": "1.0.0",
   "license": "SEE LICENSE IN LICENSE.MD",
   "workspaces": [
     "packages/*"
@@ -14,6 +13,7 @@
     "prettier:check": "prettier --check 'packages/**/*.{js,ts,json}'",
     "prettier:makeitpretty": "prettier --write 'packages/**/*.{js,ts,json}'",
     "test": "turbo run test",
-    "test:coverage": "turbo run test:coverage && ./scripts/test-coverage.sh"
+    "test:coverage": "turbo run test:coverage && ./scripts/test-coverage.sh",
+    "version": "npm install -w=packages && changeset version"
   }
 }


### PR DESCRIPTION
Automates updating monorepo dependencies at the root by using changset's custom version script. When changeset makes a release PR, it will also include a package-lock update to the monorepo root