### PR TITLE
Fix test coverage with dependabot

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.test_coverage.outputs.coverage_results }}
+          token: ${{ secrets.MEROXA_MACHINE }}


### PR DESCRIPTION
Uses our automated machine token for posting coverage results

Makes sure that dependabot PRs are scoped to a token that can post comments

See it in action below 👇 