### PR TITLE
fix: use correct format for deployment IR

### DIFF
--- a/.changeset/quick-gorillas-live.md
+++ b/.changeset/quick-gorillas-live.md
@@ -1,0 +1,5 @@
+---
+"@meroxa/turbine-js-cli": patch
+---
+
+fix: use correct format for deployment IR

--- a/packages/turbine-js-cli/src/runner/primary.ts
+++ b/packages/turbine-js-cli/src/runner/primary.ts
@@ -144,7 +144,7 @@ export default class Primary {
 
     try {
       await this.dataApp.run(environment);
-      const IR = environment.serializeToIR();
+      const IR = environment.serializeToDeployment();
       console.log(IR);
       // POST IR
       return Ok(true);

--- a/packages/turbine-js-cli/test/unit/platform-v2-test.ts
+++ b/packages/turbine-js-cli/test/unit/platform-v2-test.ts
@@ -10,20 +10,27 @@ QUnit.module("Unit | PlatformV2Function", () => {
     const funktion = new PlatformV2Function(
       "sleep-token-fn",
       "123456789",
-      "sleep-token-image"
+      "sleep-token-image",
+      { SUPER_SECRET: "NOPEEKING" }
     );
     assert.strictEqual(funktion.name, "sleep-token-fn-12345678");
     assert.strictEqual(funktion.image, "sleep-token-image");
+    assert.strictEqual(funktion.env_vars.SUPER_SECRET, "NOPEEKING");
   });
-  QUnit.test("#serializeToIR", (assert) => {
+
+  QUnit.test("#serializeToDeployment", (assert) => {
     const funktion = new PlatformV2Function(
       "sleep-token-fn",
       "123456789",
-      "sleep-token-image"
+      "sleep-token-image",
+      { SUPER_SECRET: "NOPEEKING" }
     );
-    assert.deepEqual(funktion.serializeToIR(), {
+    assert.deepEqual(funktion.serializeToDeployment(), {
       name: "sleep-token-fn-12345678",
       image: "sleep-token-image",
+      env_vars: {
+        SUPER_SECRET: "NOPEEKING",
+      },
     });
   });
 });
@@ -89,7 +96,7 @@ QUnit.module("Unit | PlatformV2Runtime", () => {
     assert.strictEqual(runtime.spec, "0.1.0");
   });
 
-  QUnit.test("#definition", (assert) => {
+  QUnit.test("#metadata", (assert) => {
     const runtime = new PlatformV2Runtime(
       "imageName",
       "appName",
@@ -98,15 +105,10 @@ QUnit.module("Unit | PlatformV2Runtime", () => {
       "0.1.0"
     );
 
-    assert.deepEqual(runtime.definition, {
-      app_name: "appName",
-      git_sha: "123456789",
-      metadata: {
-        turbine: {
-          language: "js",
-          version: "1.0.0",
-        },
-        spec_version: "0.1.0",
+    assert.deepEqual(runtime.metadata, {
+      turbine: {
+        language: "js",
+        version: "1.0.0",
       },
     });
   });
@@ -151,7 +153,7 @@ QUnit.module("Unit | PlatformV2Runtime", () => {
     assert.strictEqual(runtime.registeredSecrets.A_ENV_VAR, "sleeptokenrocks");
   });
 
-  QUnit.test("#serializeToIR", (assert) => {
+  QUnit.test("#serializeToDeployment", (assert) => {
     const runtime = new PlatformV2Runtime(
       "imageName",
       "appName",
@@ -173,34 +175,38 @@ QUnit.module("Unit | PlatformV2Runtime", () => {
     const destination = runtime.resources("a-dest");
     destination.write({} as Records, "dest_collection", { DEST_CONFIG: "bye" });
 
-    const IR = runtime.serializeToIR();
+    const IR = runtime.serializeToDeployment();
 
     assert.deepEqual(IR, {
-      connectors: [
-        {
-          resource: "a-source",
-          type: "source",
-          collection: "source_collection",
-          config: { SOURCE_CONFIG: "hey" },
-        },
-        {
-          resource: "a-dest",
-          type: "destination",
-          collection: "dest_collection",
-          config: { DEST_CONFIG: "bye" },
-        },
-      ],
-      functions: [{ name: "aFn-12345678", image: "imageName" }],
-      secrets: { A_ENV_VAR: "sleeptokenrocks" },
-      definition: {
-        app_name: "appName",
-        git_sha: "123456789",
+      git_sha: "123456789",
+      spec_version: "0.1.0",
+      spec: {
+        connectors: [
+          {
+            resource: "a-source",
+            type: "source",
+            collection: "source_collection",
+            config: { SOURCE_CONFIG: "hey" },
+          },
+          {
+            resource: "a-dest",
+            type: "destination",
+            collection: "dest_collection",
+            config: { DEST_CONFIG: "bye" },
+          },
+        ],
+        functions: [
+          {
+            name: "aFn-12345678",
+            image: "imageName",
+            env_vars: { A_ENV_VAR: "sleeptokenrocks" },
+          },
+        ],
         metadata: {
           turbine: {
             language: "js",
             version: "1.0.0",
           },
-          spec_version: "0.1.0",
         },
       },
     });


### PR DESCRIPTION
Updates the IR format to match what is in our RFC for the deployment request data. 

The actual type of the deployment request can eventually be moved into meroxa-js and then imported here. 