### PR TITLE
chore(npm): provide additional aliases for npm commands used in local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "turbo": "^1.5.5"
   },
   "scripts": {
+    "build:dev": "npx turbo build:dev",
+    "packages": "npm install -w packages",
+    "local:meroxa-js": "npm link @meroxa/meroxa-js -w packages/turbine-js-cli",
     "prettier:check": "prettier --check 'packages/**/*.{js,ts,json}'",
     "prettier:makeitpretty": "prettier --write 'packages/**/*.{js,ts,json}'",
     "test": "turbo run test",


### PR DESCRIPTION
This adds a few aliases for npm commands that we may want to use during local development, including

- `npm run build:dev`: builds the `turbine-js-cli` binary automatically from the root of the monorepo
- `npm run packages`: installs package dependencies form the root of the monorepo
- `npm run local:meroxa-js`: links to the local version of `meroxa-js` if said repo has been initialized previously using `npm link`