### PR TITLE
Prefer javascript to js in the backend

### DIFF
--- a/.changeset/no-abbreviations-in-appsjson.md
+++ b/.changeset/no-abbreviations-in-appsjson.md
@@ -1,0 +1,5 @@
+---
+"@meroxa/turbine-js-cli": patch
+---
+
+fix: prefer javascript to js in the backend app.json

--- a/packages/turbine-js-cli/src/runner/primary.ts
+++ b/packages/turbine-js-cli/src/runner/primary.ts
@@ -159,7 +159,7 @@ export default class Primary {
     try {
       const applicationInput = {
         name: appConfig.name,
-        language: "js",
+        language: "javascript",
         git_sha: headCommit,
         pipeline: {
           name: appConfig.pipeline,


### PR DESCRIPTION
This value is not modified before being saved to the Platform API db.  We left it more open there so that we didn't have to update the types every time we added support for a language, or maybe we thought the CLI would handle it.  I can't remember at this point, but the turbine-go and turbine-python libraries do not use any abbreviations for this value. 