### PR TITLE
upd(local): add error messages for missing resources / collections on meroxa apps run

### DIFF
--- a/.changeset/orange-schools-share.md
+++ b/.changeset/orange-schools-share.md
@@ -1,0 +1,5 @@
+---
+"@meroxa/turbine-js-cli": patch
+---
+
+upd(local): add error messages for failed local app run due to missing or wrongly configured app fixtures

--- a/packages/turbine-js-cli/src/runner/primary.ts
+++ b/packages/turbine-js-cli/src/runner/primary.ts
@@ -40,8 +40,13 @@ export default class Primary {
   }
 
   async runAppLocal() {
-    await this.dataApp.run(this.localRuntime);
-    return Ok(true);
+    try {
+      await this.dataApp.run(this.localRuntime);
+      return Ok(true);
+    } catch (e) {
+      assertIsError(e);
+      return Err(new BaseError("Error running Turbine Data app locally", e));
+    }
   }
 
   async listFunctions(): Promise<Result<string[], BaseError>> {

--- a/packages/turbine-js-cli/src/runtime/local.ts
+++ b/packages/turbine-js-cli/src/runtime/local.ts
@@ -79,7 +79,7 @@ async function readFixtures(
   if (!collectionFixtures || collectionFixtures === "undefined") {
     let currentTableName = Object.keys(fixtures)[0];
     throw new BaseError(
-      `You are trying to read from a resource "${resourceName}" with the collection "${collection}" but the local fixture that you have defined for this resource in app.json does not contain a table named "${collection}".\nPlease define another fixture file for "${resourceName}" in your app.json or update the table name in your currently used fixture from "${currentTableName}" to "${collection}".\n`
+      `You are trying to read from a resource "${resourceName}" with the collection "${collection}" but the local fixture that you have associated with this resource in app.json does not contain a table named "${collection}".\nPlease associate another fixture file for "${resourceName}" in your app.json or update the table name in your currently used fixture from "${currentTableName}" to "${collection}".\n`
     );
   }
   let records = new RecordsArray();

--- a/packages/turbine-js-cli/src/runtime/local.ts
+++ b/packages/turbine-js-cli/src/runtime/local.ts
@@ -1,3 +1,4 @@
+import { BaseError } from "../errors";
 import {
   Resource,
   Record,
@@ -11,16 +12,26 @@ import { readFile } from "fs/promises";
 export class LocalRuntime implements Runtime {
   appConfig: AppConfig;
   pathToApp: string;
+  hasSource: boolean;
 
   constructor(pathToApp: string, appConfig: AppConfig) {
     this.pathToApp = pathToApp;
     this.appConfig = appConfig;
+    this.hasSource = false;
   }
 
   resources(resourceName: string): LocalResource {
     const resources = this.appConfig.resources;
     const fixturesPath = resources[resourceName];
+
+    if ((!fixturesPath || fixturesPath === "undefined") && !this.hasSource) {
+      throw new BaseError(
+        `You are trying to run your Turbine Data app with the resource "${resourceName}" which currently does not have a local fixture defined in your app config.\nPlease define a suitable fixture file for "${resourceName}" in ${this.pathToApp}/app.json before running the meroxa apps run command again.\n`
+      );
+    }
+
     const resourceFixturesPath = `${this.pathToApp}/${fixturesPath}`;
+    this.hasSource = true;
 
     return new LocalResource(resourceName, resourceFixturesPath);
   }
@@ -65,6 +76,12 @@ async function readFixtures(
   const rawFixtures = await readFile(path);
   let fixtures = JSON.parse(rawFixtures.toString());
   let collectionFixtures = fixtures[collection];
+  if (!collectionFixtures || collectionFixtures === "undefined") {
+    let currentTableName = Object.keys(fixtures)[0];
+    throw new BaseError(
+      `You are trying to read from a resource "${resourceName}" with the collection "${collection}" but the local fixture that you have defined for this resource in app.json does not contain a table named "${collection}".\nPlease define another fixture file for "${resourceName}" in your app.json or update the table name in your currently used fixture from "${currentTableName}" to "${collection}".\n`
+    );
+  }
   let records = new RecordsArray();
 
   collectionFixtures.forEach((fixture: any) => {

--- a/packages/turbine-js-cli/src/runtime/local.ts
+++ b/packages/turbine-js-cli/src/runtime/local.ts
@@ -26,7 +26,7 @@ export class LocalRuntime implements Runtime {
 
     if ((!fixturesPath || fixturesPath === "undefined") && !this.hasSource) {
       throw new BaseError(
-        `You are trying to run your Turbine Data app with the resource "${resourceName}" which currently does not have a local fixture defined in your app config.\nPlease define a suitable fixture file for "${resourceName}" in ${this.pathToApp}/app.json before running the meroxa apps run command again.\n`
+        `You are trying to run your Turbine Data app with the resource "${resourceName}" which currently does not have a local fixture association in your app config.\nPlease associate a suitable fixture file for "${resourceName}" in ${this.pathToApp}/app.json before running the meroxa apps run command again.\n`
       );
     }
 

--- a/packages/turbine-js-cli/test/mock_app/index.js
+++ b/packages/turbine-js-cli/test/mock_app/index.js
@@ -1,0 +1,8 @@
+exports.App = class App {
+  async run(turbine) {
+    let source = await turbine.resources("pg");
+    let records = await source.records("collection_name");
+    let destination = await turbine.resources("snowflake");
+    await destination.write(records, "output_collection");
+  }
+};

--- a/packages/turbine-js-cli/test/mock_app/mock_fixtures/demo-cdc.json
+++ b/packages/turbine-js-cli/test/mock_app/mock_fixtures/demo-cdc.json
@@ -1,0 +1,454 @@
+{
+  "collection_name": [
+    {
+      "key": "1",
+      "value": {
+        "schema": {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "id", "optional": false, "type": "int32" },
+                { "field": "category", "optional": false, "type": "string" },
+                {
+                  "field": "product_type",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "product_name",
+                  "optional": false,
+                  "type": "string"
+                },
+                { "field": "stock", "optional": false, "type": "boolean" },
+                { "field": "product_id", "optional": false, "type": "int32" },
+                {
+                  "field": "shipping_address",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "customer_email",
+                  "optional": false,
+                  "type": "varchar"
+                }
+              ],
+              "optional": true,
+              "name": "resource.public.collection_name.Value",
+              "field": "before"
+            },
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "id", "optional": false, "type": "int32" },
+                { "field": "category", "optional": false, "type": "string" },
+                {
+                  "field": "product_type",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "product_name",
+                  "optional": false,
+                  "type": "string"
+                },
+                { "field": "stock", "optional": false, "type": "boolean" },
+                { "field": "product_id", "optional": false, "type": "int32" },
+                {
+                  "field": "shipping_address",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "customer_email",
+                  "optional": false,
+                  "type": "varchar"
+                }
+              ],
+              "optional": true,
+              "name": "resource.public.collection_name.Value",
+              "field": "after"
+            },
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "version", "optional": false, "type": "string" },
+                { "field": "connector", "optional": false, "type": "string" },
+                { "field": "name", "optional": false, "type": "string" },
+                { "field": "ts_ms", "optional": false, "type": "int64" },
+                {
+                  "name": "io.debezium.data.Enum",
+                  "optional": true,
+                  "type": "string",
+                  "version": 1,
+                  "parameters": {
+                    "allowed": "true,last,false"
+                  },
+                  "default": "false",
+                  "field": "snapshot"
+                },
+                { "field": "db", "optional": false, "type": "string" },
+                { "field": "schema", "optional": false, "type": "string" },
+                { "field": "table", "optional": false, "type": "string" },
+                { "field": "txId", "optional": true, "type": "int64" },
+                { "field": "lsn", "optional": true, "type": "int64" },
+                { "field": "xmin", "optional": true, "type": "int64" }
+              ],
+              "optional": false,
+              "name": "io.debezium.connector.postgresql.Source",
+              "field": "source"
+            },
+            { "field": "op", "optional": false, "type": "string" },
+            { "field": "ts_ms", "optional": true, "type": "int64" },
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "id", "optional": false, "type": "string" },
+                { "field": "total_order", "optional": false, "type": "int64" },
+                {
+                  "field": "data_collection_order",
+                  "optional": false,
+                  "type": "int64"
+                }
+              ],
+              "optional": true,
+              "field": "transaction"
+            }
+          ],
+          "optional": false,
+          "name": "resource.public.collection_name.Envelope"
+        },
+        "payload": {
+          "before": null,
+          "after": {
+            "id": 9582724,
+            "category": "camping",
+            "product_type": "sleeping-bag",
+            "product_name": "Forte 35 Sleeping Bag - Womens",
+            "stock": true,
+            "product_id": 361632,
+            "shipping_address": "9718 East Virginia Avenue Silver Spring, MD 20901",
+            "customer_email": "usera@example.com"
+          },
+          "source": {
+            "version": "1.2.5.Final",
+            "connector": "postgresql",
+            "name": "source_name",
+            "ts_ms": 1644362356740,
+            "snapshot": "true",
+            "db": "database",
+            "schema": "public",
+            "table": "collection_name",
+            "lsn": 537810437656,
+            "txId": 8680,
+            "xmin": null
+          },
+          "op": "r",
+          "ts_ms": 1644362356743,
+          "transaction": null
+        }
+      }
+    },
+    {
+      "key": "2",
+      "value": {
+        "schema": {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "id", "optional": false, "type": "int32" },
+                { "field": "category", "optional": false, "type": "string" },
+                {
+                  "field": "product_type",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "product_name",
+                  "optional": false,
+                  "type": "string"
+                },
+                { "field": "stock", "optional": false, "type": "boolean" },
+                { "field": "product_id", "optional": false, "type": "int32" },
+                {
+                  "field": "shipping_address",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "customer_email",
+                  "optional": false,
+                  "type": "varchar"
+                }
+              ],
+              "optional": true,
+              "name": "resource.public.collection_name.Value",
+              "field": "before"
+            },
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "id", "optional": false, "type": "int32" },
+                { "field": "category", "optional": false, "type": "string" },
+                {
+                  "field": "product_type",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "product_name",
+                  "optional": false,
+                  "type": "string"
+                },
+                { "field": "stock", "optional": false, "type": "boolean" },
+                { "field": "product_id", "optional": false, "type": "int32" },
+                {
+                  "field": "shipping_address",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "customer_email",
+                  "optional": false,
+                  "type": "varchar"
+                }
+              ],
+              "optional": true,
+              "name": "resource.public.collection_name.Value",
+              "field": "after"
+            },
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "version", "optional": false, "type": "string" },
+                { "field": "connector", "optional": false, "type": "string" },
+                { "field": "name", "optional": false, "type": "string" },
+                { "field": "ts_ms", "optional": false, "type": "int64" },
+                {
+                  "name": "io.debezium.data.Enum",
+                  "optional": true,
+                  "type": "string",
+                  "version": 1,
+                  "parameters": {
+                    "allowed": "true,last,false"
+                  },
+                  "default": "false",
+                  "field": "snapshot"
+                },
+                { "field": "db", "optional": false, "type": "string" },
+                { "field": "schema", "optional": false, "type": "string" },
+                { "field": "table", "optional": false, "type": "string" },
+                { "field": "txId", "optional": true, "type": "int64" },
+                { "field": "lsn", "optional": true, "type": "int64" },
+                { "field": "xmin", "optional": true, "type": "int64" }
+              ],
+              "optional": false,
+              "name": "io.debezium.connector.postgresql.Source",
+              "field": "source"
+            },
+            { "field": "op", "optional": false, "type": "string" },
+            { "field": "ts_ms", "optional": true, "type": "int64" },
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "id", "optional": false, "type": "string" },
+                { "field": "total_order", "optional": false, "type": "int64" },
+                {
+                  "field": "data_collection_order",
+                  "optional": false,
+                  "type": "int64"
+                }
+              ],
+              "optional": true,
+              "field": "transaction"
+            }
+          ],
+          "optional": false,
+          "name": "resource.public.collection_name.Envelope"
+        },
+        "payload": {
+          "before": null,
+          "after": {
+            "id": 9582725,
+            "category": "camping",
+            "product_type": "sleeping-bag",
+            "product_name": "Cosmic 20 Sleeping Bag - Mens",
+            "stock": true,
+            "product_id": 235367,
+            "shipping_address": "881 South Newbridge Lane Upland, CA 91784",
+            "customer_email": "userb@example.com"
+          },
+          "source": {
+            "version": "1.2.5.Final",
+            "connector": "postgresql",
+            "name": "source_name",
+            "ts_ms": 1644362356740,
+            "snapshot": "true",
+            "db": "database",
+            "schema": "public",
+            "table": "collection_name",
+            "lsn": 537810437656,
+            "txId": 8680,
+            "xmin": null
+          },
+          "op": "r",
+          "ts_ms": 1644362356743,
+          "transaction": null
+        }
+      }
+    },
+    {
+      "key": "3",
+      "value": {
+        "schema": {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "id", "optional": false, "type": "int32" },
+                { "field": "category", "optional": false, "type": "string" },
+                {
+                  "field": "product_type",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "product_name",
+                  "optional": false,
+                  "type": "string"
+                },
+                { "field": "stock", "optional": false, "type": "boolean" },
+                { "field": "product_id", "optional": false, "type": "int32" },
+                {
+                  "field": "shipping_address",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "customer_email",
+                  "optional": false,
+                  "type": "varchar"
+                }
+              ],
+              "optional": true,
+              "name": "resource.public.collection_name.Value",
+              "field": "before"
+            },
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "id", "optional": false, "type": "int32" },
+                { "field": "category", "optional": false, "type": "string" },
+                {
+                  "field": "product_type",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "product_name",
+                  "optional": false,
+                  "type": "string"
+                },
+                { "field": "stock", "optional": false, "type": "boolean" },
+                { "field": "product_id", "optional": false, "type": "int32" },
+                {
+                  "field": "shipping_address",
+                  "optional": false,
+                  "type": "string"
+                },
+                {
+                  "field": "customer_email",
+                  "optional": false,
+                  "type": "varchar"
+                }
+              ],
+              "optional": true,
+              "name": "resource.public.collection_name.Value",
+              "field": "after"
+            },
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "version", "optional": false, "type": "string" },
+                { "field": "connector", "optional": false, "type": "string" },
+                { "field": "name", "optional": false, "type": "string" },
+                { "field": "ts_ms", "optional": false, "type": "int64" },
+                {
+                  "name": "io.debezium.data.Enum",
+                  "optional": true,
+                  "type": "string",
+                  "version": 1,
+                  "parameters": {
+                    "allowed": "true,last,false"
+                  },
+                  "default": "false",
+                  "field": "snapshot"
+                },
+                { "field": "db", "optional": false, "type": "string" },
+                { "field": "schema", "optional": false, "type": "string" },
+                { "field": "table", "optional": false, "type": "string" },
+                { "field": "txId", "optional": true, "type": "int64" },
+                { "field": "lsn", "optional": true, "type": "int64" },
+                { "field": "xmin", "optional": true, "type": "int64" }
+              ],
+              "optional": false,
+              "name": "io.debezium.connector.postgresql.Source",
+              "field": "source"
+            },
+            { "field": "op", "optional": false, "type": "string" },
+            { "field": "ts_ms", "optional": true, "type": "int64" },
+            {
+              "type": "struct",
+              "fields": [
+                { "field": "id", "optional": false, "type": "string" },
+                { "field": "total_order", "optional": false, "type": "int64" },
+                {
+                  "field": "data_collection_order",
+                  "optional": false,
+                  "type": "int64"
+                }
+              ],
+              "optional": true,
+              "field": "transaction"
+            }
+          ],
+          "optional": false,
+          "name": "resource.public.collection_name.Envelope"
+        },
+        "payload": {
+          "before": null,
+          "after": {
+            "id": 9582726,
+            "category": "camping",
+            "product_type": "sleeping-bag",
+            "product_name": "Zephyr 25 Recycled Sleeping Bag - Kid",
+            "stock": true,
+            "product_id": 203000,
+            "shipping_address": "43 Sunnyslope Street Port Richey, FL 34668",
+            "customer_email": "userc@example.com"
+          },
+          "source": {
+            "version": "1.2.5.Final",
+            "connector": "postgresql",
+            "name": "source_name",
+            "ts_ms": 1644362356740,
+            "snapshot": "true",
+            "db": "database",
+            "schema": "public",
+            "table": "collection_name",
+            "lsn": 537810437656,
+            "txId": 8680,
+            "xmin": null
+          },
+          "op": "r",
+          "ts_ms": 1644362356743,
+          "transaction": null
+        }
+      }
+    }
+  ]
+}

--- a/packages/turbine-js-cli/test/unit/local-runtime-test.ts
+++ b/packages/turbine-js-cli/test/unit/local-runtime-test.ts
@@ -18,29 +18,128 @@ QUnit.module("Unit | LocalRuntime", () => {
     assert.strictEqual(subject.pathToApp, pathToDataApp);
   });
 
-  QUnit.test("#resources", (assert) => {
-    const pathToFixtures = "path/to/fixtures";
-    const appConfig: AppConfig = {
-      name: "sleep-token",
-      language: "js",
-      environment: "common",
-      pipeline: "default",
-      resources: {
-        pg: pathToFixtures,
-      },
-    };
+  QUnit.test(
+    "#resources: it uses the correct fixture for the resource",
+    (assert) => {
+      const pathToFixtures = "path/to/fixtures";
+      const appConfig: AppConfig = {
+        name: "sleep-token",
+        language: "js",
+        environment: "common",
+        pipeline: "default",
+        resources: {
+          pg: pathToFixtures,
+        },
+      };
 
-    const pathToDataApp = "/path/to/data/app";
-    const localRuntime = new LocalRuntime(pathToDataApp, appConfig);
-    const subject = localRuntime.resources("pg");
+      const pathToDataApp = "/path/to/data/app";
+      const localRuntime = new LocalRuntime(pathToDataApp, appConfig);
+      const subject = localRuntime.resources("pg");
 
-    assert.strictEqual(subject.constructor.name, "LocalResource");
-    assert.strictEqual(subject.name, "pg");
-    assert.strictEqual(
-      subject.fixturesPath,
-      `${pathToDataApp}/${pathToFixtures}`
-    );
-  });
+      assert.strictEqual(subject.constructor.name, "LocalResource");
+      assert.strictEqual(subject.name, "pg");
+      assert.strictEqual(
+        subject.fixturesPath,
+        `${pathToDataApp}/${pathToFixtures}`
+      );
+    }
+  );
+
+  QUnit.test(
+    "#resources: it throws an error if there is no fixture defined for the resource",
+    (assert) => {
+      const pathToFixtures = "path/to/fixtures";
+      const appConfig: AppConfig = {
+        name: "sleep-token",
+        language: "js",
+        environment: "common",
+        pipeline: "default",
+        resources: {
+          pg: pathToFixtures,
+        },
+      };
+
+      const pathToDataApp = "/path/to/data/app";
+      const localRuntime = new LocalRuntime(pathToDataApp, appConfig);
+
+      assert.throws(
+        function () {
+          localRuntime.resources("wild_MISSINGNO");
+        },
+        /You are trying to run your Turbine Data app with the resource "wild_MISSINGNO"/,
+        "it throws the error"
+      );
+    }
+  );
+
+  QUnit.test(
+    "#records: it returns records read from the source fixture",
+    async (assert) => {
+      const pathToFixtures = "./mock_fixtures/demo-cdc.json";
+      const appConfig: AppConfig = {
+        name: "sleep-token",
+        language: "js",
+        environment: "common",
+        pipeline: "default",
+        resources: {
+          pg: pathToFixtures,
+        },
+      };
+
+      const pathToDataApp = "test/mock_app";
+      const localRuntime = new LocalRuntime(pathToDataApp, appConfig);
+      const resource = localRuntime.resources("pg");
+
+      const subject = await resource.records("collection_name");
+      assert.strictEqual(subject.records.length, 3);
+      assert.strictEqual(subject.records[0].key, "1");
+      assert.strictEqual(subject.records[0].value.schema.fields.length, 6);
+      assert.strictEqual(subject.records[0].value.payload.before, null);
+      assert.deepEqual(subject.records[0].value.payload.after, {
+        id: 9582724,
+        category: "camping",
+        product_type: "sleeping-bag",
+        product_name: "Forte 35 Sleeping Bag - Womens",
+        stock: true,
+        product_id: 361632,
+        shipping_address: "9718 East Virginia Avenue Silver Spring, MD 20901",
+        customer_email: "usera@example.com",
+      });
+    }
+  );
+
+  QUnit.test(
+    "#records: it throws an error if there is no matching collection defined in the fixture",
+    async (assert) => {
+      assert.expect(2);
+
+      const pathToFixtures = "./mock_fixtures/demo-cdc.json";
+      const appConfig: AppConfig = {
+        name: "sleep-token",
+        language: "js",
+        environment: "common",
+        pipeline: "default",
+        resources: {
+          pg: pathToFixtures,
+        },
+      };
+
+      const pathToDataApp = "test/mock_app";
+      const localRuntime = new LocalRuntime(pathToDataApp, appConfig);
+      const subject = localRuntime.resources("pg");
+
+      try {
+        await subject.records("snorlax");
+      } catch (e) {
+        assert.ok(true, "it throws an error");
+        assert.ok(
+          e.message.includes(
+            `You are trying to read from a resource "pg" with the collection "snorlax" but the local fixture`
+          )
+        );
+      }
+    }
+  );
 
   QUnit.test("#process", (assert) => {
     const pathToFixtures = "path/to/fixtures";


### PR DESCRIPTION
Closes https://github.com/meroxa/turbine-js/issues/241

This provides more detailed error messaging if resources or fixture tables are missing when running `meroxa apps run` on a turbine-js app.

## Blockers

- [x] add changeset
- [x] add tests
- [x] add demo to PR

## Before 

**Missing resource in app.json**

```bash
./meroxa apps run --path ../demos/jj-oracle-to-redshifts3snowflake/

Error: node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[Error: ENOENT: no such file or directory, open '/Users/jj/go/src/github.com/meroxa/demos/jj-oracle-to-redshifts3snowflake/undefined'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/jj/go/src/github.com/meroxa/demos/jj-oracle-to-redshifts3snowflake/undefined'
}
```

**Wrong collection name in fixture**

```bash
$ ./meroxa apps run --path ../demos/jj-oracle-to-redshifts3snowflake/

Error: Error running Turbine Data app locally : Cannot read properties of undefined (reading 'forEach')
```

## After

### New

**Missing resource in app.json**

```bash
$ ./meroxa apps run --path ../demos/jj-oracle-to-redshifts3snowflake/

Error: Error running Turbine Data app locally : You are trying to run your Turbine Data app with the resource "oracle-march15" which currently does not have a local fixture defined in your app config.
Please define a suitable fixture file for "oracle-march15" in /Users/jj/go/src/github.com/meroxa/demos/jj-oracle-to-redshifts3snowflake/app.json before running the meroxa apps run command again.
```

**Wrong collection name in fixture**


```bash
$ ./meroxa apps run --path ../demos/jj-oracle-to-redshifts3snowflake/

Error: Error running Turbine Data app locally : You are trying to read from a resource "oracle-march15" with the collection "orders" but the local fixture that you have defined for this resource in app.json does not contain a table named "orders".
Please define another fixture file for "oracle-march15" in your app.json or update the table name in your currently used fixture from "collection_name" to "orders".
```

## Demo

### Default

![errorme_normal](https://user-images.githubusercontent.com/8811742/225907119-625219c0-e97f-42c1-9af2-3b343bd62b3b.gif)

### Wrong Fixture File

![errorme_wrongresource](https://user-images.githubusercontent.com/8811742/225907494-7678862e-ef7b-404c-9804-a8dcb231fd92.gif)


### Wrong Table in Fixture File Defined

![errorme_wrongtable](https://user-images.githubusercontent.com/8811742/225907319-7ec967a1-313a-4147-8f03-2119aa8d757f.gif)



