### PR TITLE
fix: mongo set and unwrapping

### DIFF
--- a/.changeset/forty-years-deny.md
+++ b/.changeset/forty-years-deny.md
@@ -1,0 +1,5 @@
+---
+"@meroxa/turbine-js": patch
+---
+
+fix: mongo set and unwrapping


### PR DESCRIPTION
Fixes some small bugs with mongo to best account for the data formats coming from mongo. Notably, we can't really handle using set on any other operations besides creates for mongo due to the `patch` field. 

This fix also makes sure that during mongo create events, we are properly parsing the value to json, and then back to a string.

`set` is a best effort function to handle modifying data on all of the different type of CDC events until we get schema normalization. User's still have the escape hatch of manipulating records directly via `record.value` or `record.key`